### PR TITLE
Add overload to use Defer::then(Defer) with rvalues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ endmacro(use_cxx11)
 
 
 project(promise)
+set(PROJECT_VERSION 1.0.0)
 use_cxx11()
 aux_source_directory(. DIR_SRCS)
 include_directories(.)
@@ -32,6 +33,13 @@ add_executable(simple_benchmark_test test/simple_benchmark_test.cpp)
 add_executable(chain_defer_test test/chain_defer_test.cpp)
 enable_testing()
 add_test(chain_defer_test chain_defer_test)
+
+install(FILES promise.hpp DESTINATION include)
+file(GLOB PROMISE_HEADERS promise/*.hpp)
+install(FILES ${PROMISE_HEADERS} DESTINATION include/promise)
+configure_file(build/promise-cpp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/promise-cpp.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/promise-cpp.pc DESTINATION lib/pkgconfig)
+unset(PROJECT_VERSION)
 
 
 project(asio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ include_directories(.)
 add_executable(test0 test/test0.cpp)
 add_executable(simple_timer test/simple_timer.cpp)
 add_executable(simple_benchmark_test test/simple_benchmark_test.cpp)
+add_executable(chain_defer_test test/chain_defer_test.cpp)
+enable_testing()
+add_test(chain_defer_test chain_defer_test)
 
 
 project(asio)

--- a/build/promise-cpp.pc.in
+++ b/build/promise-cpp.pc.in
@@ -1,0 +1,7 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: promise-cpp
+Description: C++ promise/A+ library in Javascript style.
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}

--- a/promise.hpp
+++ b/promise.hpp
@@ -430,6 +430,10 @@ public:
         return object_->then(promise);
     }
 
+    Defer then(Defer&& promise) {
+        return then(promise);
+    }
+
     template <typename FUNC_ON_RESOLVED, typename FUNC_ON_REJECTED>
     Defer then(FUNC_ON_RESOLVED on_resolved, FUNC_ON_REJECTED on_rejected) const {
         return object_->template then<FUNC_ON_RESOLVED, FUNC_ON_REJECTED>(on_resolved, on_rejected);

--- a/test/chain_defer_test.cpp
+++ b/test/chain_defer_test.cpp
@@ -1,0 +1,29 @@
+#include "promise.hpp"
+#include <sstream>
+#include <iostream>
+
+promise::Defer writeTo(std::ostream& out) {
+    return promise::newHeadPromise().then([&out](int value) {
+        out << value;
+        return promise::reject(std::string(" testErrorReason "));
+    }, [&out](const std::string& reason) {
+        out << reason;
+        return 456;
+    });
+}
+
+int main() {
+    promise::Defer d = promise::newHeadPromise();
+    std::ostringstream out;
+    promise::Defer writeToOut = writeTo(out);
+    d.then(writeToOut).then(writeTo(out)).then(writeTo(out));
+    d.resolve(123);
+
+    std::string expected = "123 testErrorReason 456";
+    if (out.str() != expected) {
+        std::cout << "FAIL chain_defer_test got \"" << out.str() << "\", "
+                  << "expected \"" << expected << "\"\n";
+        return 1;
+    }
+    std::cout << "PASS\n";
+}


### PR DESCRIPTION
Hello, thank you for sharing your code.

I'd like to call `then(f())` with a function that returns a promise. My suggestion is to add an overload for Defer&&, but anything that makes the included test pass is fine with me.

I'd also suggest to provide an "install" target.

Happy new year, Paul