### PR TITLE
Include dir is now public and example builds optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ project(promise)
 
 # build shared option
 option(PROMISE_BUILD_SHARED "Build shared library" OFF)
+option(PROMISE_BUILD_EXAMPLES "Build examples" ON)
 
 set(my_headers
     include/promise-cpp/promise.hpp
@@ -30,8 +31,6 @@ set(my_sources
     Readme.md
 )
 
-include_directories(include .)
-
 if(PROMISE_BUILD_SHARED OR BUILD_SHARED_LIBS)
     add_definitions(-DPROMISE_BUILD_SHARED)
     add_library(promise SHARED ${my_sources} ${my_headers})
@@ -39,55 +38,7 @@ else()
     add_library(promise STATIC ${my_sources} ${my_headers})
 endif()
 
-
-add_executable(test0 ${my_headers} example/test0.cpp)
-target_link_libraries(test0 PRIVATE promise)
-
-add_executable(simple_timer ${my_headers} example/simple_timer.cpp)
-target_link_libraries(simple_timer PRIVATE promise)
-
-add_executable(simple_benchmark_test ${my_headers} example/simple_benchmark_test.cpp)
-target_link_libraries(simple_benchmark_test PRIVATE promise)
-
-find_package(Threads)
-if(Threads_FOUND)
-    add_executable(multithread_test ${my_headers} example/multithread_test.cpp)
-    target_link_libraries(multithread_test PRIVATE promise Threads::Threads)
-endif()
-
-add_executable(chain_defer_test ${my_headers} example/chain_defer_test.cpp)
-target_link_libraries(chain_defer_test PRIVATE promise)
-
-
-find_package(Boost)
-if(NOT Boost_FOUND)
-    message(WARNING "Boost not found, so asio projects will not be compiled")
-else()
-
-    include_directories(${Boost_INCLUDE_DIRS})
-    if (UNIX)
-        link_libraries(pthread)
-    endif (UNIX)
-
-    include_directories(. ./add_ons/asio)
-    
-    add_executable(asio_benchmark_test ${my_headers} example/asio_benchmark_test.cpp)
-    target_compile_definitions(asio_benchmark_test PRIVATE BOOST_ALL_NO_LIB)  
-    target_link_libraries(asio_benchmark_test PRIVATE promise)
-
-    add_executable(asio_timer ${my_headers} example/asio_timer.cpp)
-    target_compile_definitions(asio_timer PRIVATE BOOST_ALL_NO_LIB)  
-    target_link_libraries(asio_timer PRIVATE promise)
-
-    add_executable(asio_http_client ${my_headers} example/asio_http_client.cpp)
-    target_compile_definitions(asio_http_client PRIVATE BOOST_ALL_NO_LIB)  
-    target_link_libraries(asio_http_client PRIVATE promise)
-
-    add_executable(asio_http_server ${my_headers} example/asio_http_server.cpp)
-    target_compile_definitions(asio_http_server PRIVATE BOOST_ALL_NO_LIB)  
-    target_link_libraries(asio_http_server PRIVATE promise)
-endif()
-
+target_include_directories(promise PUBLIC include)
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets)
@@ -100,13 +51,64 @@ else()
         add_library(promise_qt STATIC ./add_ons/qt/promise_qt.cpp ${my_headers})
     endif()
     target_link_libraries(promise_qt PRIVATE promise Qt${QT_VERSION_MAJOR}::Widgets)
-    
-    add_subdirectory(./example/qt_timer)
 endif()
 
-find_package(MFC)
-if(NOT MFC_FOUND)
-    message(WARNING "MFC not found, so project mfc_timer will not be compiled")
-else()
-    add_subdirectory(./example/mfc_timer)
+if(PROMISE_BUILD_EXAMPLES) 
+    add_executable(test0 ${my_headers} example/test0.cpp)
+    target_link_libraries(test0 PRIVATE promise)
+
+    add_executable(simple_timer ${my_headers} example/simple_timer.cpp)
+    target_link_libraries(simple_timer PRIVATE promise)
+
+    add_executable(simple_benchmark_test ${my_headers} example/simple_benchmark_test.cpp)
+    target_link_libraries(simple_benchmark_test PRIVATE promise)
+
+    find_package(Threads)
+    if(Threads_FOUND)
+        add_executable(multithread_test ${my_headers} example/multithread_test.cpp)
+        target_link_libraries(multithread_test PRIVATE promise Threads::Threads)
+    endif()
+
+    add_executable(chain_defer_test ${my_headers} example/chain_defer_test.cpp)
+    target_link_libraries(chain_defer_test PRIVATE promise)
+
+    find_package(Boost)
+    if(NOT Boost_FOUND)
+        message(WARNING "Boost not found, so asio projects will not be compiled")
+    else()
+
+        include_directories(${Boost_INCLUDE_DIRS})
+        if (UNIX)
+            link_libraries(pthread)
+        endif (UNIX)
+
+        include_directories(. ./add_ons/asio)
+        
+        add_executable(asio_benchmark_test ${my_headers} example/asio_benchmark_test.cpp)
+        target_compile_definitions(asio_benchmark_test PRIVATE BOOST_ALL_NO_LIB)  
+        target_link_libraries(asio_benchmark_test PRIVATE promise)
+
+        add_executable(asio_timer ${my_headers} example/asio_timer.cpp)
+        target_compile_definitions(asio_timer PRIVATE BOOST_ALL_NO_LIB)  
+        target_link_libraries(asio_timer PRIVATE promise)
+
+        add_executable(asio_http_client ${my_headers} example/asio_http_client.cpp)
+        target_compile_definitions(asio_http_client PRIVATE BOOST_ALL_NO_LIB)  
+        target_link_libraries(asio_http_client PRIVATE promise)
+
+        add_executable(asio_http_server ${my_headers} example/asio_http_server.cpp)
+        target_compile_definitions(asio_http_server PRIVATE BOOST_ALL_NO_LIB)  
+        target_link_libraries(asio_http_server PRIVATE promise)
+    endif()
+
+    if(QT_FOUND)
+        add_subdirectory(./example/qt_timer)
+    endif()
+
+    find_package(MFC)
+    if(NOT MFC_FOUND)
+        message(WARNING "MFC not found, so project mfc_timer will not be compiled")
+    else()
+        add_subdirectory(./example/mfc_timer)
+    endif()
 endif()


### PR DESCRIPTION
target_link_library(mything PRIVATE promise)

is not sufficient, because promise does not provide its include directory to the using target.
I changed that.

I also made the example builds optional via an option, so I can omit them in my project.
**Please crosscheck that I didnt opt-out too much!**

