### PR TITLE
fix: warning: declaration of 'lock' shadows a previous local [-Wshadow]

### DIFF
--- a/include/promise-cpp/promise_inl.hpp
+++ b/include/promise-cpp/promise_inl.hpp
@@ -176,11 +176,11 @@ static inline void call(std::shared_ptr<Task> task) {
                         //to next resolved task
                     }
                     else {
-                        promiseHolder->state_ = TaskState::kPending; // 避免递归任务再次使用
+                        promiseHolder->state_ = TaskState::kPending; // 閬垮厤閫掑綊浠诲姟鍐嶆浣跨敤
 #if PROMISE_MULTITHREAD
                         std::shared_ptr<Mutex> mutex0 = nullptr;
                         auto call = [&]() -> any {
-                            unlock_guard_t lock(mutex);
+                            unlock_guard_t lock_inner(mutex);
                             const any &value = task->onResolved_.call(promiseHolder->value_);
                             // Make sure the returned promised is locked before than "mutex"
                             if (value.type() == type_id<Promise>()) {
@@ -227,11 +227,11 @@ static inline void call(std::shared_ptr<Task> task) {
                     }
                     else {
                         try {
-                            promiseHolder->state_ = TaskState::kPending; // 避免递归任务再次使用
+                            promiseHolder->state_ = TaskState::kPending; // 閬垮厤閫掑綊浠诲姟鍐嶆浣跨敤
 #if PROMISE_MULTITHREAD
                             std::shared_ptr<Mutex> mutex0 = nullptr;
                             auto call = [&]() -> any {
-                                unlock_guard_t lock(mutex);
+                                unlock_guard_t lock_inner(mutex);
                                 const any &value = task->onRejected_.call(promiseHolder->value_);
                                 // Make sure the returned promised is locked before than "mutex"
                                 if (value.type() == type_id<Promise>()) {


### PR DESCRIPTION
I swore I submitted this as a PR, but for the life of me I cannot find it.  This removes a warning for a lock that is shadowed.  In theory I shouldn't be an issue, but I noticed a few errors in helgrind warning about mutex locks forming out of order.  99.9% sure its boost asio, but this caught my eye.